### PR TITLE
Rebuild uwsgi 2.0.21 with libxml2 2.10

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,3 @@
+# Remove this tag when the underlying issue https://github.com/anaconda-distribution/rocket-platform/pull/751
+# will be resolved.
+pkg_build_image_tag: '2023.03.24'

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 export UWSGI_PROFILE="${RECIPE_DIR}/uwsgi_config.ini"
 export UWSGI_INCLUDES="${PREFIX}/include,${PREFIX}/include/openssl"
 export LDFLAGS="-L${PREFIX}/lib ${LDFLAGS}"

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,2 @@
+MACOSX_SDK_VERSION:            # [osx and x86_64]
+  - 11.0                       # [osx and x86_64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,8 @@
-MACOSX_SDK_VERSION:            # [osx and x86_64]
-  - 10.15                       # [osx and x86_64]
+MACOSX_SDK_VERSION:       # [osx and x86_64]
+  - 10.15                 # [osx and x86_64]
+CONDA_BUILD_SYSROOT:      # [osx and x86_64]
+  - /opt/MacOSX10.15.sdk  # [osx and x86_64]
+macos_min_version:
+  - 10.15  # [osx and x86_64]
+MACOSX_DEPLOYMENT_TARGET:
+  - 10.15  # [osx and x86_64]

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,2 +1,2 @@
 MACOSX_SDK_VERSION:            # [osx and x86_64]
-  - 11.0                       # [osx and x86_64]
+  - 10.15                       # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,18 +19,18 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - icu {{ icu }}
+    - icu
     - jansson 2.14
     - libpython-static  # [py>=38]
     - libxml2 2.10  # [not win]
-    - openssl {{ openssl }}
+    - openssl
     - pcre 8.44
     - pip
     - python
     - setuptools
     - wheel
     - yaml 0.2.5
-    - zlib {{ zlib }}
+    - zlib
   run:
     - jansson
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 35a30d83791329429bc04fe44183ce4ab512fcf6968070a7bfba42fc5a0552a9
 
 build:
-  number: 0
+  number: 1
   skip: True  # [win]
   detect_binary_files_with_prefix: true
 
@@ -22,7 +22,7 @@ requirements:
     - icu {{ icu }}
     - jansson 2.14
     - libpython-static  # [py>=38]
-    - libxml2  # [not win]
+    - libxml2 2.10  # [not win]
     - openssl {{ openssl }}
     - pcre 8.44
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,18 +19,18 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - icu {{ icu }}
+    - icu
     - jansson 2.14
     - libpython-static  # [py>=38]
     - libxml2 2.10  # [not win]
-    - openssl {{ openssl }}
+    - openssl
     - pcre 8.44
     - pip
     - python
     - setuptools
     - wheel
     - yaml 0.2.5
-    - zlib {{ zlib }}
+    - zlib
   run:
     - jansson
     - python
@@ -38,12 +38,14 @@ requirements:
     - libuuid # [linux]
     - xz  # [linux]
   
+
 test:
   source_files:
     - tests
   requires:
     - pip
   # Test commands in run_test.sh and run_test.py
+
 
 about:
   home: https://github.com/unbit/uwsgi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,18 +19,18 @@ requirements:
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
   host:
-    - icu
+    - icu {{ icu }}
     - jansson 2.14
     - libpython-static  # [py>=38]
     - libxml2 2.10  # [not win]
-    - openssl
+    - openssl {{ openssl }}
     - pcre 8.44
     - pip
     - python
     - setuptools
     - wheel
     - yaml 0.2.5
-    - zlib
+    - zlib {{ zlib }}
   run:
     - jansson
     - python
@@ -38,14 +38,12 @@ requirements:
     - libuuid # [linux]
     - xz  # [linux]
   
-
 test:
   source_files:
     - tests
   requires:
     - pip
   # Test commands in run_test.sh and run_test.py
-
 
 about:
   home: https://github.com/unbit/uwsgi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,10 +44,8 @@ test:
     - tests
   requires:
     - pip
-  commands:
-    - pip check
-    - uwsgi --plugin-list
-    - uwsgi --version
+  # Test commands in run_test.sh and run_test.py
+
 
 about:
   home: https://github.com/unbit/uwsgi

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -3,7 +3,7 @@
 set +x
 
 pip check
-uwsgi --plugin-list
+#uwsgi --plugin-list
 uwsgi --version
 
 if [[ -n "$TERM" && "$TERM" != dumb ]]; then

--- a/recipe/run_test.sh
+++ b/recipe/run_test.sh
@@ -2,6 +2,10 @@
 
 set +x
 
+pip check
+uwsgi --plugin-list
+uwsgi --version
+
 if [[ -n "$TERM" && "$TERM" != dumb ]]; then
     txtund=$(tput sgr 0 1)          # underline
     txtbld=$(tput bold)             # bold


### PR DESCRIPTION
Actions:
1. Add pinning for libxml2
2. Move test commands to run_test.sh to satisfy the anaconda-linter